### PR TITLE
Add persistent channels and members panel

### DIFF
--- a/server/models/Message.js
+++ b/server/models/Message.js
@@ -1,0 +1,10 @@
+const mongoose = require('mongoose');
+
+const messageSchema = new mongoose.Schema({
+  server: { type: mongoose.Schema.Types.ObjectId, ref: 'Server', required: true },
+  channel: { type: String, required: true },
+  user: { type: String, required: true },
+  message: { type: String, required: true },
+}, { timestamps: true });
+
+module.exports = mongoose.model('Message', messageSchema);

--- a/server/models/Server.js
+++ b/server/models/Server.js
@@ -17,6 +17,10 @@ const serverSchema = new mongoose.Schema({
     required: true,
     unique: true
   },
+  channels: {
+    type: [String],
+    default: ['general']
+  },
   members: [{
     type: mongoose.Schema.Types.ObjectId,
     ref: 'User'

--- a/src/App.css
+++ b/src/App.css
@@ -9,7 +9,13 @@ body { font-family: Arial, sans-serif; }
 
 .container { display:flex; height:100vh; }
 .sidebar { width:80px; background:#202225; padding:10px 0; box-sizing:border-box; display:flex; flex-direction:column; align-items:center; }
+.channelbar { width:150px; background:#2b2d31; color:#fff; padding:10px; box-sizing:border-box; }
+.memberbar { width:150px; background:#2b2d31; color:#fff; padding:10px; box-sizing:border-box; overflow-y:auto; }
 .sidebar button { width:48px; height:48px; margin-bottom:12px; background:#5865f2; color:#fff; border:none; border-radius:50%; cursor:pointer; font-size:20px; display:flex; align-items:center; justify-content:center; }
+.channel-list { list-style:none; padding:0; margin:0; }
+.channel { padding:6px; cursor:pointer; }
+.channel.active { background:#5865f2; }
+.member { padding:4px 0; font-size:14px; }
 .server-list { list-style:none; padding:0; margin:0; width:100%; display:flex; flex-direction:column; align-items:center; }
 .server { width:48px; height:48px; margin-bottom:12px; background:#36393f; color:#b9bbbe; border-radius:50%; display:flex; align-items:center; justify-content:center; cursor:pointer; font-weight:bold; }
 .server.active { background:#5865f2; color:#fff; }


### PR DESCRIPTION
## Summary
- track messages in MongoDB
- include channels field in server model
- expose HTTP routes for channels, messages and members
- store online users
- expose owner ID in login response
- show channels and members lists in React UI
- load message history and channel list

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68752cb7df04832086620c2c1a6c6d12