### PR TITLE
Add user profile customization

### DIFF
--- a/server/models/User.js
+++ b/server/models/User.js
@@ -3,7 +3,9 @@ const mongoose = require('mongoose');
 
 const userSchema = new mongoose.Schema({
   username: { type: String, required: true, unique: true },
-  passwordHash: { type: String, required: true }
+  passwordHash: { type: String, required: true },
+  avatar: String,
+  banner: String
 }, { timestamps: true });
 
 module.exports = mongoose.model('User', userSchema);

--- a/src/App.js
+++ b/src/App.js
@@ -3,12 +3,13 @@ import React, { useState, useEffect } from 'react';
 import io    from 'socket.io-client';
 import axios from 'axios';
 import Signup from './Signup';
+import Profile from './Profile';
 import './App.css';
 
 const API = 'http://127.0.0.1:3001';
 
 function App() {
-  const [stage, setStage]       = useState('login');    // 'login'|'signup'|'menu'|'create'|'join'|'chat'
+  const [stage, setStage]       = useState('login');    // 'login'|'signup'|'menu'|'create'|'join'|'chat'|'profile'
   const [token, setToken]       = useState(localStorage.getItem('token') || '');
   const [username, setUsername] = useState(localStorage.getItem('username') || '');
   const [userId, setUserId]     = useState(localStorage.getItem('userId') || '');
@@ -244,10 +245,24 @@ function App() {
     );
   }
 
+  if (stage === 'profile') {
+    return (
+      <Profile
+        token={token}
+        onClose={()=>setStage('chat')}
+        onUpdate={data=>{
+          setUsername(data.username);
+          setToken(data.token);
+        }}
+      />
+    );
+  }
+
   // Chat principal
   return (
     <div className="container">
       <aside className="sidebar">
+        <button onClick={()=>setStage('profile')}>⚙️</button>
         <button onClick={()=>setStage('create')}>➕</button>
         <button onClick={()=>setStage('join')}>➡️</button>
         <ul className="server-list">
@@ -322,8 +337,9 @@ function App() {
       <aside className="memberbar">
         <strong>Membres</strong>
         {members.map(m => (
-          <div key={m.username} className="member">
-            {m.username} - {m.online ? 'en ligne' : 'hors ligne'}
+          <div key={m.username} className="member" style={{ display:'flex', alignItems:'center', marginBottom:4 }}>
+            {m.avatar && <img src={m.avatar} alt="av" style={{ width:24, height:24, borderRadius:'50%', marginRight:4 }} />}
+            <span>{m.username} - {m.online ? 'en ligne' : 'hors ligne'}</span>
           </div>
         ))}
       </aside>

--- a/src/Profile.js
+++ b/src/Profile.js
@@ -1,0 +1,59 @@
+import React, { useState, useEffect } from 'react';
+import axios from 'axios';
+
+const API = 'http://127.0.0.1:3001';
+
+export default function Profile({ token, onClose, onUpdate }) {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [avatar, setAvatar] = useState('');
+  const [banner, setBanner] = useState('');
+
+  useEffect(() => {
+    axios.get(`${API}/me`, { headers: { Authorization: `Bearer ${token}` } })
+      .then(res => {
+        setUsername(res.data.username);
+        setAvatar(res.data.avatar || '');
+        setBanner(res.data.banner || '');
+      });
+  }, [token]);
+
+  const toBase64 = file => new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result);
+    reader.onerror = reject;
+    reader.readAsDataURL(file);
+  });
+
+  const submit = async e => {
+    e.preventDefault();
+    const body = { username, password, avatar, banner };
+    try {
+      const res = await axios.put(`${API}/me`, body, { headers: { Authorization: `Bearer ${token}` } });
+      onUpdate(res.data);
+      onClose();
+    } catch (err) {
+      alert(err.response?.data?.error || 'Erreur');
+    }
+  };
+
+  return (
+    <div className="centered">
+      <form onSubmit={submit} className="form">
+        <h2>Profil</h2>
+        <input placeholder="Nom d'utilisateur" value={username} onChange={e=>setUsername(e.target.value)} />
+        <input type="password" placeholder="Nouveau mot de passe" value={password} onChange={e=>setPassword(e.target.value)} />
+        <div style={{ marginTop:8 }}>
+          <input type="file" accept="image/*" onChange={async e=>setAvatar(await toBase64(e.target.files[0]))} />
+          {avatar && <img src={avatar} alt="avatar" style={{ width:80, height:80, borderRadius:'50%', display:'block', marginTop:8 }} />}
+        </div>
+        <div style={{ marginTop:8 }}>
+          <input type="file" accept="image/*" onChange={async e=>setBanner(await toBase64(e.target.files[0]))} />
+          {banner && <img src={banner} alt="banner" style={{ width:'100%', height:60, objectFit:'cover', display:'block', marginTop:8 }} />}
+        </div>
+        <button type="submit">Enregistrer</button>
+        <p className="link" onClick={onClose}>Annuler</p>
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- allow avatar and banner fields in the user schema
- add /me endpoint to read and update profile
- expose avatar info in server member listing
- add Profile component in the frontend
- add profile button in chat sidebar and member avatar display

## Testing
- `npm test --silent --unsafe-perm` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68753074f14083208582144b00e11303